### PR TITLE
Make `date` and `placeholder` attrs bindable

### DIFF
--- a/build/lib.js
+++ b/build/lib.js
@@ -91,6 +91,8 @@ Ember.Pikaday.PikadayComponent = Ember.Component.extend({
         var date = moment(this.get('value'));
         if (date.isValid()) {
             this.set('date', date.toDate());
+        } else if (this.get('value').trim() === '') {
+            this.set('date', null);
         }
         // else: Value is invalid. Wait for it to validate.
     }.observes('value'),


### PR DESCRIPTION
I think is a common use case to show an input with a placeholder without defaulting to any value. In order to achieve that, `placeholder` and `date` attributes must be binded.

Here's a simple example of how it should behave and look:

``` javascript
pik-a-day type='text' placeholder='From'
pik-a-day type='text' date='' placeholder='To'
```

![screen shot 2014-11-05 at 5 11 46 pm](https://cloud.githubusercontent.com/assets/1371000/4924058/b22eccd8-651f-11e4-9234-c3730f8faa59.png)
